### PR TITLE
Remove deprecated implementation of payment method label under gateway settings #13

### DIFF
--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -114,7 +114,7 @@ class Give_Payumoney_Gateway_Settings {
 	public function add_settings( $settings ) {
 		$current_section = give_get_current_setting_section();
 
-		if ( $this->section_id == $current_section ) {
+		if ( $this->section_id === $current_section ) {
 			$settings = array(
 				array(
 					'id'   => 'give_payumoney_payments_setting',

--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -121,13 +121,6 @@ class Give_Payumoney_Gateway_Settings {
 					'type' => 'title',
 				),
 				array(
-					'title'   => __( 'Payment Method Label', 'give-payumoney' ),
-					'id'      => 'payumoney_payment_method_label',
-					'type'    => 'text',
-					'default' => give_payu_get_payment_method_label(),
-					'desc'    => __( 'Payment method label will be appear on frontend.', 'give-payumoney' ),
-				),
-				array(
 					'title' => __( 'Live Merchant Key', 'give-payumoney' ),
 					'id'    => 'payumoney_live_merchant_key',
 					'type'  => 'text',


### PR DESCRIPTION
## Description
This PR resolves #13 

## How Has This Been Tested?
I've tested this PR by changing the payment method label as per Give core 2.0.0 functionality.

## Types of changes
Bug fix (a non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.