### PR TITLE
fix: unable to save payumoney as an active gateway #18

### DIFF
--- a/give-paymoney.php
+++ b/give-paymoney.php
@@ -5,7 +5,7 @@
  * Description: Process online donations via the PayUmoney payment gateway.
  * Author: GiveWP
  * Author URI: https://givewp.com
- * Version: 1.0.4
+ * Version: 1.0.5
  * Text Domain: give-payumoney
  * Domain Path: /languages
  * GitHub Plugin URI: https://github.com/impress-org/give-payumoney
@@ -79,7 +79,7 @@ if ( ! class_exists( 'Give_Payumoney_Gateway' ) ) {
 		 */
 		public function setup_constants() {
 			// Global Params.
-			define( 'GIVE_PAYU_VERSION', '1.0.4' );
+			define( 'GIVE_PAYU_VERSION', '1.0.5' );
 			define( 'GIVE_PAYU_MIN_GIVE_VER', '2.3.0' );
 			define( 'GIVE_PAYU_BASENAME', plugin_basename( __FILE__ ) );
 			define( 'GIVE_PAYU_URL', plugins_url( '/', __FILE__ ) );

--- a/includes/actions.php
+++ b/includes/actions.php
@@ -86,3 +86,40 @@ function give_payumoney_cc_form_callback( $form_id ) {
 }
 
 add_action( 'give_payumoney_cc_form', 'give_payumoney_cc_form_callback' );
+
+
+/**
+ * Register Gateway Admin Notices for PayUMoney add-on.
+ *
+ * @since 1.0.5
+ *
+ * @return void
+ */
+function give_payumoney_show_admin_notice() {
+
+	// Bailout, if not admin.
+	if ( ! is_admin() ) {
+		return;
+	}
+
+	// Show currency notice, if currency is not set as "Indian Rupee".
+	if (
+		current_user_can( 'manage_give_settings' ) &&
+		'INR' !== give_get_currency() &&
+		! class_exists( 'Give_Currency_Switcher' ) // Disable Notice, if Currency Switcher add-on is enabled.
+	) {
+		Give()->notices->register_notice( array(
+			'id'          => 'give-payumoney-currency-notice',
+			'type'        => 'error',
+			'dismissible' => false,
+			'description' => sprintf(
+				__( 'The currency must be set as "Indian Rupee (₹)" within Give\'s <a href="%s">Currency Settings</a> in order to collect donations through the PayUMoney Payment Gateway.', 'give-payumoney' ),
+				admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=general&section=currency-settings' )
+			),
+			'show'        => true,
+		) );
+	}
+
+}
+
+add_action( 'admin_notices', 'give_payumoney_show_admin_notice' );

--- a/includes/actions.php
+++ b/includes/actions.php
@@ -19,32 +19,6 @@ function give_payumoney_set_donation_abandoned_callback( $payment_id ) {
 
 add_action( 'give_payumoney_set_donation_abandoned', 'give_payumoney_set_donation_abandoned_callback' );
 
-
-/**
- * Validate payumoney settings.
- *
- * @since 1.0
- *
- * @param $options
- */
-function give_payu_validate_settings( $options ) {
-	if ( isset( $options['gateways']['payumoney'] ) && ( 'INR' !== $options['currency'] ) ) {
-		// Unset payumoney.
-		unset( $options['gateways']['payumoney'] );
-
-		// Show payment gateway disable notice to admin.
-		Give_Admin_Settings::add_error(
-			'give_payu_no_inr_currency',
-			esc_html__( 'The PayUmoney payment gateway has been disabled because INR is not set as the donation currency.', 'give-payumoney' )
-		);
-
-		// Update options.
-		update_option( 'give_settings', $options );
-	}
-}
-
-add_action( 'give_save_settings_give_settings', 'give_payu_validate_settings' );
-
 /**
  * Add phone field.
  *

--- a/includes/admin/actions.php
+++ b/includes/admin/actions.php
@@ -5,63 +5,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Check if PayUmoney dependency enable or not.
- *
- * @since 1.0
- */
-function give_payumoney_check_dependancies() {
-	// Bailout
-	if ( ! give_is_payu_active() ) {
-		return;
-	}
-
-	// Get core settings.
-	$give_settings  = give_get_settings();
-	$reset_settings = false;
-
-	// Check dependencies.
-	if ( ! give_payu_is_sandbox_mode_enabled() && ( empty( $give_settings['payumoney_live_merchant_key'] ) || empty( $give_settings['payumoney_live_salt_key'] ) ) ) {
-		$reset_settings = true;
-
-		// Show notice.
-		add_filter( 'give-settings_update_notices', 'give_payu_disable_by_agent_credentials' );
-	} elseif ( give_payu_is_sandbox_mode_enabled() && ( empty( $give_settings['payumoney_sandbox_merchant_key'] ) || empty( $give_settings['payumoney_sandbox_salt_key'] ) ) ) {
-		$reset_settings = true;
-
-		// Show notice.
-		add_filter( 'give-settings_update_notices', 'give_payu_disable_by_agent_credentials' );
-	}
-
-	// Bailout.
-	if ( ! $reset_settings ) {
-		return;
-	}
-
-	// Deactivate PayUmoney payment gateways: It has some currency dependency.
-	unset( $give_settings['gateways']['payumoney'] );
-
-	// Update settings.
-	update_option( 'give_settings', $give_settings );
-}
-
-add_action( 'give-settings_saved', 'give_payumoney_check_dependancies' );
-
-
-/**
- * Add message when PayUmoney disable by agent credentials.
- *
- * @param array $messages
- *
- * @return mixed
- */
-function give_payu_disable_by_agent_credentials( $messages ) {
-	$messages['give-payumoney-disable'] = sprintf( __( 'The PayUmoney payment gateway has been disabled automatically because the <a href="%s">merchant credentials</a> are not correct.', 'give-payumoney' ), admin_url( 'edit.php?post_type=give_forms&page=give-settings&tab=gateways&section=payumoney' ) );
-
-	return $messages;
-}
-
-
-/**
  * Show transaction ID under donation meta.
  *
  * @since 1.0

--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -82,7 +82,7 @@ class Give_Payumoney_Gateway_Settings {
 		$gateways[ $this->section_id ] = array(
 			'admin_label'    => __( 'PayUMoney - India', 'payumoney' ),
 			'checkout_label' => give_payu_get_payment_method_label(),
-			'admin_tooltip'  => __( 'Only INR currency is supported by PayUMoney. Hence, the indian PayUMoney accounts are supported.', 'give-stripe' ),
+			'admin_tooltip'  => __( 'Only INR currency is supported by PayUMoney. Hence, the Indian PayUMoney accounts are only supported.', 'give-stripe' ),
 		);
 
 		return $gateways;

--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -80,8 +80,9 @@ class Give_Payumoney_Gateway_Settings {
 	 */
 	public function add_gateways( $gateways ) {
 		$gateways[ $this->section_id ] = array(
-			'admin_label'    => $this->section_label,
+			'admin_label'    => __( 'PayUMoney - India', 'payumoney' ),
 			'checkout_label' => give_payu_get_payment_method_label(),
+			'admin_tooltip'  => __( 'Only INR currency is supported by PayUMoney. Hence, the indian PayUMoney accounts are supported.', 'give-stripe' ),
 		);
 
 		return $gateways;

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: givewp
 Tags: donations, donation, ecommerce, e-commerce, fundraising, fundraiser, payumoney, gateway
 Requires at least: 4.5
 Tested up to: 5.0
-Stable tag: 1.0.4
+Stable tag: 1.0.5
 License: GPLv3
 License URI: https://opensource.org/licenses/GPL-3.0
 


### PR DESCRIPTION
## Description
This PR resolves #18 

## How Has This Been Tested?
I've tested this PR as per the acceptance criteria on the issue description.

## Screenshots (jpeg or gifs if applicable):
**Notice displayed when currency switcher add-on is not active and other than INR is set as base currency**
![image](https://user-images.githubusercontent.com/1852711/66015496-6b993f00-e4f0-11e9-9367-caf8396f890a.png)

**Renamed gateway in admin and added tooltip for better explanation**
![image](https://user-images.githubusercontent.com/1852711/66015530-89ff3a80-e4f0-11e9-8bdc-23d57ec3c1d7.png)

## Types of changes
Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] My code is tested.
- [x] My code follows the WordPress code style.
- [x] My code follows has proper inline documentation.